### PR TITLE
change appengine source to be modular

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sossity "0.1.1-SNAPSHOT"
+(defproject sossity "0.3.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/src/sossity/config_schema.clj
+++ b/src/sossity/config_schema.clj
@@ -1,6 +1,5 @@
 (ns sossity.config-schema
-  (:require
-   [schema.core :as s]))
+  (:require [schema.core :as s]))
 
 (def sys-jar {:name s/Str :pail s/Str :key s/Str})
 
@@ -10,7 +9,7 @@
              :sink-resource-version s/Str
              :default-error-bucket-batch-size s/Int
              :source-resource-version s/Str
-             :appengine-gstoragekey s/Str
+             :source {:name s/Str :pail s/Str :key s/Str}
              :default-sink-docker-image s/Str
              :appengine-sinkkey s/Str
              :system-jar-info {:angleddream sys-jar :sossity sys-jar}
@@ -19,8 +18,7 @@
 
 (def cluster {:name s/Str :initial_node_count s/Int :master_auth {:username s/Str :password s/Str} :node_config {:oauth_scopes [s/Str] :machine_type s/Str}})
 
-(def opts {:maxNumWorkers   s/Int :numWorkers s/Int :zone s/Str
-           :stagingLocation s/Str})
+(def opts {:maxNumWorkers s/Int :numWorkers s/Int :zone s/Str :autoscalingAlgorithm s/Str :stagingLocation s/Str})
 
 (def provider {:credentials s/Str :project s/Str})
 
@@ -58,6 +56,7 @@
                 (s/optional-key :error-out) s/Bool
                 (s/optional-key :bigQuerySchema) s/Str
                 (s/optional-key :sink_type) s/Str
+                (s/optional-key :dataset_name) s/Str
                 (s/optional-key :rsys_pass) s/Str
                 (s/optional-key :rsys_user) s/Str
                 (s/optional-key :rsys_table) s/Str


### PR DESCRIPTION
put into the config a proper `:pail :key :name` in order to specify properly within which bucket to find the app engine source folder. Should not put in system-jar because that is picked up by version parses and it will unnecessarily download source locally.